### PR TITLE
Allow to pass data-root to command line

### DIFF
--- a/bin/generate.js
+++ b/bin/generate.js
@@ -10,9 +10,10 @@ program
   .option('-c, --config <location>', 'Location of the exported Insomnia JSON config.')
   .option('-l, --logo <location>', 'Project logo location (48x48px PNG).')
   .option('-o, --output <location>', 'Where to save the file (defaults to current working directory).')
+  .option('-d, --data-root <docs-root>', 'Docs root for the API documentation.', '')
   .parse(process.argv);
 
-const { config, logo, output } = program;
+const { config, logo, output, dataRoot } = program;
 
 if (!config) {
   console.log('You must provide an exported Insomnia config (Preferences -> Data -> Export Data -> Current Workspace).');
@@ -45,6 +46,19 @@ mkdirp(outputPath, err => {
   if (logoPath) {
     console.log('Adding custom logo...');
     fs.copyFileSync(logoPath, path.join(outputPath, 'logo.png'));
+  }
+
+  try {
+    const data = fs.readFileSync(path.join(outputPath, 'index.html'), 'utf8')
+    var result = data.replace('DATAROOT', dataRoot);
+  } catch (err) {
+    console.error(err)
+  }
+
+  try {
+    fs.writeFileSync(path.join(outputPath, 'index.html'), result)
+  } catch (err) {
+    console.error(err)
   }
 
   console.log('\n * * * Done! * * *\nYour documentation has been created and it\'s ready to be deployed!');

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,6 @@
 </head>
 <body>
   <noscript>In order to view this documentation page, you have to enable JavaScript in your web browser.</noscript>
-  <div id="app"></div>
+  <div id="app" data-root="DATAROOT"></div>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,6 @@
 </head>
 <body>
   <noscript>In order to view this documentation page, you have to enable JavaScript in your web browser.</noscript>
-  <div id="app" data-root="DATAROOT"></div>
+  <div id="app"></div>
 </body>
 </html>


### PR DESCRIPTION
As explained in https://github.com/jozsefsallai/insomnia-documenter#custom-root-paths we can change the `data-root` attribute to use custom root paths, but we want to automatize this and have made this change to allow to pass this option to command line executable

`insomnia-documenter -c Insomnia.json -o docs -d /docs`